### PR TITLE
fix WP_Media element js template to show selected image when thumbnai…

### DIFF
--- a/src/forms/elements/class-wp-media.php
+++ b/src/forms/elements/class-wp-media.php
@@ -128,7 +128,11 @@ class WP_Media extends Form_Component {
 			<div class="thumbnail">
 				<% if ( ! _.isEmpty( attributes.sizes ) ) { %>
 				<div class="centered">
-					<img src="<%- attributes.sizes.thumbnail.url %>" alt="<%- attributes.title %>" width="<%- attributes.sizes.thumbnail.width %>" heigt="<%- attributes.sizes.thumbnail.height %>">
+					<% if ( ! _.isEmpty( attributes.sizes.thumbnail ) ) { %>
+						<img src="<%- attributes.sizes.thumbnail.url %>" alt="<%- attributes.title %>" width="<%- attributes.sizes.thumbnail.width %>" heigt="<%- attributes.sizes.thumbnail.height %>">
+					<% } else { %>	
+						<img src="<%- attributes.sizes.full.url %>" alt="<%- attributes.title %>" width="<%- attributes.sizes.full.width %>" heigt="<%- attributes.sizes.full.height %>">
+					<% } %>
 				</div>
 				<% } else { %>
 				<div class="centered">


### PR DESCRIPTION
The problem happens when the image uploaded is tinier than the thumbnail size. This problem throws a javascript error that interrupts the execution of the image selection. The image did not show as selected and you can't see it in the metabox. The assumption here is when the thumbnail did not exists the full size shouldn't be that bigger so we use that size instead.